### PR TITLE
Records support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,21 @@ Convert a JSON representation back into an immutable object
 ### `transit.withFilter(function) => transit`
 
 Create a modified version of the transit API that deeply applies the provided filter function to all immutable collections before serialising. Can be used to exclude entries.
+
+### `transit.withRecords([recordClasses])[.withFilter(function)] => transit`
+
+Creates a modified version of the transit API with support for serializing/deserializing [Record](https://facebook.github.io/immutable-js/docs/#/) objects. If a Record is included in an object to be serialized without the proper handler, on encoding it will be encoded as an `Immutable.Map`.
+
+## Example `Record` Usage:
+
+```js
+var FooRecord = Immutable.Record({
+  a: 1,
+  b: 2,
+}, 'foo');
+
+var data = new FooRecord();
+
+var recordTransit = transit.withRecords([FooRecord]);
+var encodedJSON = transit.toJSON(data);
+```

--- a/index.js
+++ b/index.js
@@ -1,47 +1,66 @@
 var transit = require('transit-js');
 var Immutable = require('immutable');
 
-var reader = transit.reader('json', {
-  mapBuilder: {
-    init: function() {
-      return {};
-    },
-    add: function(m, k, v) {
-      m[k] = v;
-      return m;
-    },
-    finalize: function(m) {
-      return m;
-    }
-  },
-  handlers: {
-    iM: function(v) {
-      var m = Immutable.Map().asMutable();
-      for (var i = 0; i < v.length; i += 2) {
-        m = m.set(v[i], v[i + 1]);
-      }
-      return m.asImmutable();
-    },
-    iOM: function(v) {
-      var m = Immutable.OrderedMap().asMutable();
-      for (var i = 0; i < v.length; i += 2) {
-        m = m.set(v[i], v[i + 1]);
-      }
-      return m.asImmutable();
-    },
-    iL: function(v) {
-      return Immutable.List(v);
-    },
-    iS: function(v) {
-      return Immutable.Set(v);
-    },
-    iOS: function(v) {
-      return Immutable.OrderedSet(v);
-    }
-  }
-});
+function recordName(record) {
+  /* eslint no-underscore-dangle: 0 */
+  return record._name;
+}
 
-var writer = createWriter(false);
+function createReader(recordMap) {
+  return transit.reader('json', {
+    mapBuilder: {
+      init: function() {
+        return {};
+      },
+      add: function(m, k, v) {
+        m[k] = v;
+        return m;
+      },
+      finalize: function(m) {
+        return m;
+      }
+    },
+    handlers: {
+      iM: function(v) {
+        var m = Immutable.Map().asMutable();
+        for (var i = 0; i < v.length; i += 2) {
+          m = m.set(v[i], v[i + 1]);
+        }
+        return m.asImmutable();
+      },
+      iOM: function(v) {
+        var m = Immutable.OrderedMap().asMutable();
+        for (var i = 0; i < v.length; i += 2) {
+          m = m.set(v[i], v[i + 1]);
+        }
+        return m.asImmutable();
+      },
+      iL: function(v) {
+        return Immutable.List(v);
+      },
+      iS: function(v) {
+        return Immutable.Set(v);
+      },
+      iOS: function(v) {
+        return Immutable.OrderedSet(v);
+      },
+      iR: function(v) {
+        var Record = recordMap[v.n];
+        if (!Record) {
+          var msg = ('Tried to deserialize Record type named `' + v.n + '`, ' +
+                     'but no type with that name was passed to withRecords()');
+          throw new Error(msg);
+        }
+
+        return Record(v.v);
+      }
+    }
+  });
+
+}
+
+var reader = createReader([]);
+var writer = createWriter(false, []);
 
 exports.toJSON = toJSON;
 function toJSON(data) {
@@ -54,7 +73,7 @@ function fromJSON(data) {
 }
 
 function withFilter(predicate) {
-  var filteredWriter = createWriter(predicate);
+  var filteredWriter = createWriter(predicate, []);
   return {
     toJSON: function(data) {
       return filteredWriter.write(data);
@@ -64,82 +83,132 @@ function withFilter(predicate) {
 }
 exports.withFilter = withFilter;
 
-function createWriter(predicate) {
+function withRecords(records, predicate) {
+  var recordMap = {};
+
+  records.forEach(function(RecordType) {
+    var rec = new RecordType({});
+
+    if (!recordName(rec)) {
+      throw new Error('Cannot (de)serialize Record() without a name field');
+    }
+
+    recordMap[recordName(rec)] = RecordType;
+  });
+
+  var recordWriter = createWriter(predicate, recordMap);
+  var recordReader = createReader(recordMap);
+
+  return {
+    toJSON: function(data) {
+      return recordWriter.write(data);
+    },
+    fromJSON: function(data) {
+      return recordReader.read(data);
+    }
+  };
+}
+exports.withRecords = withRecords;
+
+function createWriter(predicate, recordMap) {
+  var handlers = transit.map([
+    Immutable.Map, transit.makeWriteHandler({
+      tag: function() {
+        return 'iM';
+      },
+      rep: function(m) {
+        var i = 0, a = new Array(2 * m.size);
+        if (predicate) {
+          m = m.filter(predicate);
+        }
+        m.forEach(function(v, k) {
+          a[i++] = k;
+          a[i++] = v;
+        });
+        return a;
+      }
+    }),
+    Immutable.OrderedMap, transit.makeWriteHandler({
+      tag: function() {
+        return 'iOM';
+      },
+      rep: function(m) {
+        var i = 0, a = new Array(2 * m.size);
+        if (predicate) {
+          m = m.filter(predicate);
+        }
+        m.forEach(function(v, k) {
+          a[i++] = k;
+          a[i++] = v;
+        });
+        return a;
+      }
+    }),
+    Immutable.List, transit.makeWriteHandler({
+      tag: function() {
+        return "iL";
+      },
+      rep: function(v) {
+        if (predicate) {
+          v = v.filter(predicate);
+        }
+        return v.toArray();
+      }
+    }),
+    Immutable.Set, transit.makeWriteHandler({
+      tag: function() {
+        return "iS";
+      },
+      rep: function(v) {
+        if (predicate) {
+          v = v.filter(predicate);
+        }
+        return v.toArray();
+      }
+    }),
+    Immutable.OrderedSet, transit.makeWriteHandler({
+      tag: function() {
+        return "iOS";
+      },
+      rep: function(v) {
+        if (predicate) {
+          v = v.filter(predicate);
+        }
+        return v.toArray();
+      }
+    }),
+    Function, transit.makeWriteHandler({
+      tag: function() {
+        return '_';
+      },
+      rep: function() {
+        return null;
+      }
+    })
+  ]);
+
+  for (var name in recordMap) {
+    handlers.set(recordMap[name], makeRecordHandler(name, predicate));
+  }
+
   return transit.writer('json', {
-      handlers: transit.map([
-        Immutable.Map, transit.makeWriteHandler({
-          tag: function() {
-            return 'iM';
-          },
-          rep: function(m) {
-            var i = 0, a = new Array(2 * m.size);
-            if (predicate) {
-              m = m.filter(predicate);
-            }
-            m.forEach(function(v, k) {
-              a[i++] = k;
-              a[i++] = v;
-            });
-            return a;
-          }
-        }),
-        Immutable.OrderedMap, transit.makeWriteHandler({
-          tag: function() {
-            return 'iOM';
-          },
-          rep: function(m) {
-            var i = 0, a = new Array(2 * m.size);
-            if (predicate) {
-              m = m.filter(predicate);
-            }
-            m.forEach(function(v, k) {
-              a[i++] = k;
-              a[i++] = v;
-            });
-            return a;
-          }
-        }),
-        Immutable.List, transit.makeWriteHandler({
-          tag: function() {
-            return "iL";
-          },
-          rep: function(v) {
-            if (predicate) {
-              v = v.filter(predicate);
-            }
-            return v.toArray();
-          }
-        }),
-        Immutable.Set, transit.makeWriteHandler({
-          tag: function() {
-            return "iS";
-          },
-          rep: function(v) {
-            if (predicate) {
-              v = v.filter(predicate);
-            }
-            return v.toArray();
-          }
-        }),
-        Immutable.OrderedSet, transit.makeWriteHandler({
-          tag: function() {
-            return "iOS";
-          },
-          rep: function(v) {
-            if (predicate) {
-              v = v.filter(predicate);
-            }
-            return v.toArray();
-          }
-        }),
-        Function, transit.makeWriteHandler({
-          tag: function() {
-            return '_';
-          },
-          rep: function() {
-            return null;
-          }
-        })
-      ])
-    });
+    handlers: handlers
+  });
+}
+
+function makeRecordHandler(name, predicate) {
+  return transit.makeWriteHandler({
+    tag: function() {
+      return 'iR';
+    },
+    rep: function(m) {
+      if (predicate) {
+        m = m.filter(predicate);
+      }
+      return {
+        n: name,
+        v: m.toJS()
+      };
+    }
+  });
 }

--- a/test/test.js
+++ b/test/test.js
@@ -153,4 +153,65 @@ describe('transit', function() {
       expect(result.includes('a')).to.eql(false);
     });
   });
+
+  describe('records', function() {
+    var FooRecord = Immutable.Record({
+      a: '1',
+      b: '2'
+    }, 'foo');
+
+    var BarRecord = Immutable.Record({
+      c: '1',
+      d: '2'
+    }, 'bar');
+
+    var NamelessRecord = Immutable.Record({});
+
+    it('can (de)serialize Record types', function() {
+      var recordTransit = transit.withRecords([FooRecord, BarRecord]);
+
+      var input = Immutable.Map({
+        myFoo: new FooRecord(),
+        myBar: new BarRecord()
+      });
+
+      var json = recordTransit.toJSON(input);
+      var result = recordTransit.fromJSON(json);
+
+      expect(result.get('myFoo').a).to.eql('1');
+      expect(result.get('myFoo').b).to.eql('2');
+      expect(result.get('myBar').c).to.eql('1');
+      expect(result.get('myBar').d).to.eql('2');
+    });
+
+    it('throws an error when it writes an unknown record type', function() {
+      var recordTransit = transit.withRecords([]);
+
+      var input = new FooRecord();
+
+      expect(function() {
+        recordTransit.toJSON(input);
+      }).to.throw();
+    });
+
+    it('throws an error when it is passed a record with no name', function() {
+      expect(function() {
+        transit.withRecords([NamelessRecord]);
+      }).to.throw();
+    });
+
+    it('throws an error when it reads an unknown record type', function() {
+      var recordTransit = transit.withRecords([FooRecord]);
+
+      var input = new FooRecord();
+
+      var json = recordTransit.toJSON(input);
+
+      recordTransit = transit.withRecords([]);
+
+      expect(function() {
+        recordTransit.fromJSON(json);
+      }).to.throw();
+    });
+  });
 });


### PR DESCRIPTION
This PR adds record support as discussed in #7. It's based on the work by @thomasboyt in [his fork](https://github.com/thomasboyt/transit-immutable-js/commit/9eb53680420c47780fef5ff37e76c4d679a667d4?w=1), with a few modifications:

1. Nesting Records and other ImmutableJS objects within Records is supported.
2. Filter has been disabled on Record instances. It isn't a method that ImmutableJS supports on records anyway, and has [unexpected behavior](https://github.com/facebook/immutable-js/issues/220). However, a filter predicate applied to a Record instance *will* successfully filter nested ImmutableJS objects that implement `filter` such as Map (covered in the tests).
3. If no Record constructor is passed to the library for a particular Record instance, it will default to encoding the record as a Map (it still will throw an error though if you try to *decode* a Record without passing the correct constructor).
4. I've also added documentation to the README.

I think this covers everything @glenjamin asked for to merge a PR; if there's anything else necessary I'm happy to make changes!