### PR TITLE
use "new Record" to ensure record works

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,14 +45,14 @@ function createReader(recordMap) {
         return Immutable.OrderedSet(v);
       },
       iR: function(v) {
-        var Record = recordMap[v.n];
-        if (!Record) {
+        var RecordConstructor = recordMap[v.n];
+        if (!RecordConstructor) {
           var msg = 'Tried to deserialize Record type named `' + v.n + '`, ' +
                     'but no type with that name was passed to withRecords()';
           throw new Error(msg);
         }
 
-        return Record(v.v);
+        return new RecordConstructor(v.v);
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transit-immutable-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Transit serialisation for Immutable.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Immutable.js confusingly allows for two syntaxes to create a new Record object: `MyRecord({ args })` and `new MyRecord({ args })`. However, only the latter syntax works when you've created a record by extending the `Record` class instead of just calling it ([see docs](https://facebook.github.io/immutable-js/docs/#/Record)).

This PR uses the `new MyRecord` syntax, which is compatible with both ways of creating Records.

Additionally, I rename `Record` to `RecordConstructor` in the rehydration step to make it more clear that we're not dealing with Immutable's `Record` at this point.