### PR TITLE
Fix createWriter function in IE8

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function createWriter(recordMap, predicate) {
         }
         return mapSerializer(m.toMap());
       }
-    }),
+    })
   ]);
 
   Object.keys(recordMap).forEach(function(name) {


### PR DESCRIPTION
The function call `createWriter` will fail in IE8, because there is a
trailing comma when creating the `handlers` map. This trailing comma
will create an additional map item that has a key of `undefined` and
transit will throw an error.