### PR TITLE
avoid generating empty record

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/*
 coverage/*
+test/*

--- a/index.js
+++ b/index.js
@@ -189,9 +189,12 @@ function invalidExtras(data, msg) {
   throw new Error(msg.replace("%j", json));
 }
 
-function recordName(record) {
+function recordName(RecordType) {
   /* eslint no-underscore-dangle: 0 */
-  return record._name || record.constructor.name || 'Record';
+  if (RecordType.name && RecordType.name !== 'Record') {
+    return RecordType.name;
+  }
+  return (new RecordType({}))._name || 'Record';
 }
 
 function makeRecordHandler(name) {
@@ -212,8 +215,7 @@ function buildRecordMap(recordClasses) {
   var recordMap = {};
 
   recordClasses.forEach(function(RecordType) {
-    var rec = new RecordType({});
-    var recName = recordName(rec);
+    var recName = recordName(RecordType);
 
     if (!recName || recName === 'Record') {
       throw new Error('Cannot (de)serialize Record() without a name');

--- a/test/BazRecord.js
+++ b/test/BazRecord.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Immutable = require('immutable');
+
+var BazRecord = function (_Immutable$Record) {
+  _inherits(BazRecord, _Immutable$Record);
+
+  function BazRecord() {
+    _classCallCheck(this, BazRecord);
+
+    return _possibleConstructorReturn(this, (BazRecord.__proto__ || Object.getPrototypeOf(BazRecord)).apply(this, arguments));
+  }
+
+  return BazRecord;
+}(Immutable.Record({
+  e: 'a',
+  f: 'b'
+}));
+
+;
+
+module.exports = BazRecord;

--- a/test/test.js
+++ b/test/test.js
@@ -58,10 +58,7 @@ describe('transit', function() {
       d: '2'
     }, 'bar');
 
-    class BazRecord extends Immutable.Record({
-      e: 'a',
-      f: 'b'
-    }) {};
+    var BazRecord = require('./BazRecord');
 
     var NamelessRecord = Immutable.Record({});
 

--- a/test/test.js
+++ b/test/test.js
@@ -58,6 +58,11 @@ describe('transit', function() {
       d: '2'
     }, 'bar');
 
+    class BazRecord extends Immutable.Record({
+      e: 'a',
+      f: 'b'
+    }) {};
+
     var NamelessRecord = Immutable.Record({});
 
     var ClassyBase = Immutable.Record({name: 'lindsey'}, 'ClassyRecord');
@@ -65,7 +70,7 @@ describe('transit', function() {
     ClassyRecord.prototype = Object.create(ClassyBase.prototype);
     ClassyRecord.prototype.constructor = ClassyRecord;
 
-    var recordTransit = transit.withRecords([FooRecord, BarRecord]);
+    var recordTransit = transit.withRecords([FooRecord, BarRecord, BazRecord]);
 
     it('should ensure maps and records compare differently', function() {
       expectNotImmutableEqual(new FooRecord(), Immutable.Map({a: 1, b: 2}));
@@ -74,7 +79,8 @@ describe('transit', function() {
     it('should round-trip simple records', function() {
       var data = Immutable.Map({
         myFoo: new FooRecord(),
-        myBar: new BarRecord()
+        myBar: new BarRecord(),
+        myBaz: new BazRecord()
       });
 
       var roundTrip = recordTransit.fromJSON(recordTransit.toJSON(data));
@@ -85,6 +91,9 @@ describe('transit', function() {
 
       expect(roundTrip.get('myBar').c).to.eql('1');
       expect(roundTrip.get('myBar').d).to.eql('2');
+
+      expect(roundTrip.get('myBaz').e).to.eql('a');
+      expect(roundTrip.get('myBaz').f).to.eql('b');
     });
 
     it('should round-trip complex nested records', function() {


### PR DESCRIPTION
Generating empty Record can lead to bugs if you have a custom constructor.

Take this record for an exemple:
```js
cass Foo extends Record({ foo: null }) {
  constructor(input) {
    super({
      foo: input.a.b;
    })
  }
}
```

if you generate a empty record, you will have an error because input.a is not defined.

I do not really know the impact on switching the constructor name and the `_name` item, but I think `_name` should not be used (the underscore looks like it's something internal).

